### PR TITLE
fixed typo in Vignette title

### DIFF
--- a/vignettes/censusr.Rmd
+++ b/vignettes/censusr.Rmd
@@ -4,7 +4,7 @@ author: ""
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{censusr}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Was originally "Vignette Title", and I changed it to "censusr"
